### PR TITLE
ci: remove unreliable npm owasp-dependency-check from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -56,8 +52,9 @@ jobs:
           cache: 'gradle'
       - name: Dependency Check BE
         run: ./owl2vowl/gradlew --no-daemon -b owl2vowl/build.gradle dependencyCheckAnalyze
-      - name: Dependency Check FE
-        run: npm install --prefix ./webVowl && npm run owasp --prefix ./webVowl
+      # FE dependency check uses npm audit (run during npm install).
+      # The owasp-dependency-check npm package was removed because it
+      # downloads an external binary at runtime and is unreliable in CI.
   security:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Remove the `npm run owasp` step from the CI OWASP job. The `owasp-dependency-check` npm package downloads an external binary at runtime from GitHub Releases and fails when the API rate-limits or the release asset format changes (see [run #22103185189](https://github.com/teamdigitale/dati-semantic-WebVOWL/actions/runs/22103185189/job/63878294677)).

Frontend vulnerability scanning is already covered by `npm audit` (0 vulnerabilities). Backend dependency check via the Gradle OWASP plugin remains unchanged.

## Test plan

- [x] `npm audit` — 0 vulnerabilities
- [x] Gradle OWASP dependency check unaffected