### PR TITLE
Update README with deployment guide (Docker + systemd)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -56,8 +52,9 @@ jobs:
           cache: 'gradle'
       - name: Dependency Check BE
         run: ./owl2vowl/gradlew --no-daemon -b owl2vowl/build.gradle dependencyCheckAnalyze
-      - name: Dependency Check FE
-        run: npm install --prefix ./webVowl && npm run owasp --prefix ./webVowl
+      # FE dependency check uses npm audit (run during npm install).
+      # The owasp-dependency-check npm package was removed because it
+      # downloads an external binary at runtime and is unreliable in CI.
   security:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,75 +1,242 @@
-# WebOWL + OWL2VOWL distribution for schema.gov.it
+# WebVOWL + OWL2VOWL
 
-This is a release of WebOWL + OWL2VOWL for https://schema.gov.it
-where dependencies are updated and the CI includes further checks.
+WebVOWL è un visualizzatore web interattivo per ontologie OWL, basato sulla notazione Visual Notation for OWL Ontologies (VOWL). Il componente OWL2VOWL converte le ontologie OWL in formato JSON per la visualizzazione.
 
-WebVOWL
-=======
+Questo fork ([teamdigitale/dati-semantic-WebVOWL](https://github.com/teamdigitale/dati-semantic-WebVOWL)) modernizza il progetto originale [VisualDataWeb/WebVOWL](https://github.com/VisualDataWeb/WebVOWL) portandolo a:
 
-This repository was ported from an internal SVN repository to Github after the release of WebVOWL 0.4.0. Due to cleanups with `git filter-branch`, the commit history might show some strange effects.
+- **Java 21** (Eclipse Temurin) per il backend OWL2VOWL
+- **Node.js 20** per il build del frontend
+- **Spring Boot 3.x** con Tomcat embedded
+- **Gradle** (backend) + **Webpack** (frontend) come build system
+- Artifact WAR eseguibile con `java -jar` (niente Tomcat esterno)
 
+> **Nota per chi usa la versione originale con Tomcat:** le versioni precedenti di WebVOWL richiedevano il deploy di un file WAR pre-compilato su Apache Tomcat 9. Questo fork utilizza Spring Boot con Tomcat embedded: è sufficiente eseguire `java -jar owl2vowl.war`. Il deploy su un application server esterno **non è supportato né consigliato**.
 
-Requirements
-------------
+---
 
-Node.js for installing the development tools and dependencies.
+## Prerequisiti
 
+- Server Ubuntu 22.04+ (per installazione nativa) oppure Docker
 
-Development setup
------------------
+---
 
-### Simple ###
-1. Download and install Node.js from http://nodejs.org/download/
-2. Open the terminal in the root directory
-3. Run `npm install` to install the dependencies and build the project
-4. Edit the code
-5. Run `npm run build` to (re-)build all necessary files into the deploy directory
-6. Run `serve deploy/` to run the server locally, by installing serve by using `npm install serve -g`.
+## Opzione 1: Docker (consigliata)
 
-Visit [http://localhost:3000](http://localhost:3000) to use WebVOWL.
- 
-* `npm run build` builds the development version into the deploy directory
-* `npm run watch` Run webpack and watch for files changes.To check the progress of any webpack.
-* `npm run start` starts a local live-updating webserver with the current development version
-* `npm run test` starts the test runner
-* `npm run owasp` test all vulnerability with owasp
+Le immagini ufficiali sono pubblicate su GitHub Container Registry. Questa è la modalità di installazione consigliata.
 
+### 1.1 Installare Docker
 
-Additional information
-----------------------
+```bash
+sudo apt update
+sudo apt install -y docker.io
+sudo systemctl enable docker
+sudo systemctl start docker
+```
 
-To export the VOWL visualization to an SVG image, all css styles have to be included into the SVG code.
-This means that if you change the CSS code in the `vowl.css` file, you also have to update the code that
-inlines the styles - otherwise the exported SVG will not look the same as the displayed graph.
+### 1.2 Avviare il container
 
-The tool which creates the code that inlines the styles can be found in the util directory. Please
-follow the instructions in its [README](util/VowlCssToD3RuleConverter/README.md) file.
+WebVOWL non richiede variabili d'ambiente per il funzionamento base:
 
+```bash
+docker run -d \
+  --name webvowl \
+  --restart unless-stopped \
+  -p 8080:8080 \
+  ghcr.io/teamdigitale/dati-semantic-webvowl:latest
+```
 
+Verificare:
 
-OWL2VOWL converter 
-==================
+```bash
+docker logs webvowl
+# L'applicazione è disponibile su http://localhost:8080
+```
 
-Owl2Vowl is an ontology converter used to convert the given ontology to a json format that is used in the WebVOWL visualization. 
+---
 
+## Opzione 2: Installazione nativa con systemd
 
-Requirements
-------------
-*   Java 11 (or higher)
-*   Gradle
+Questa modalità prevede il build dai sorgenti e l'avvio come servizio di sistema. WebVOWL richiede sia Java che Node.js per il build.
 
-### Build the war
-To build the war file, simply execute `./gradlew clean build`. This will generate a war file.
+### 2.1 Installare Java 21
 
+```bash
+sudo apt update
+sudo apt install -y eclipse-temurin-21-jdk
+```
 
-Run Using Docker
-------------
-Make sure you are inside root directory and you have docker installed. Run the following command to build the docker image:
+Se il pacchetto non è disponibile, aggiungere il repository Adoptium:
 
-`docker compose build`
+```bash
+sudo apt install -y wget apt-transport-https gpg
+wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo gpg --dearmor -o /usr/share/keyrings/adoptium.gpg
+echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+sudo apt update
+sudo apt install -y temurin-21-jdk
+```
 
-Run the following command to run WebVOWL at port 8080. 
+### 2.2 Installare Node.js 20
 
-`docker-compose up -d` 
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+```
 
-Visit [http://localhost:8080](http://localhost:8080) to use WebVOWL.
+Verificare:
+
+```bash
+java -version
+# openjdk version "21.x.x" ...
+node --version
+# v20.x.x
+```
+
+### 2.3 Scaricare i sorgenti e buildare
+
+Il build è in due fasi: prima il frontend (Node.js), poi il backend (Gradle) che include il frontend compilato.
+
+```bash
+sudo useradd -r -s /usr/sbin/nologin webvowl
+
+cd /opt
+sudo git clone https://github.com/teamdigitale/dati-semantic-WebVOWL.git
+cd dati-semantic-WebVOWL
+
+# 1. Build del frontend
+cd webVowl
+npm install
+npm run build
+cd ..
+
+# 2. Build del backend (il Gradle task copia automaticamente il frontend dalla directory webVowl/deploy/)
+cd owl2vowl
+./gradlew clean build -x test
+cd ..
+
+# Copiare l'artifact nella directory di installazione
+sudo mkdir -p /opt/webvowl
+sudo cp owl2vowl/build/libs/owl2vowl.war /opt/webvowl/owl2vowl.war
+sudo chown -R webvowl:webvowl /opt/webvowl
+```
+
+**(Opzionale)** Rimuovere i sorgenti dopo il build per liberare spazio:
+
+```bash
+sudo rm -rf /opt/dati-semantic-WebVOWL
+```
+
+### 2.4 Creare il file di servizio systemd
+
+Creare il file `/etc/systemd/system/webvowl.service`:
+
+```ini
+[Unit]
+Description=WebVOWL - Web-based Visualization of Ontologies
+After=network.target
+
+[Service]
+Type=simple
+User=webvowl
+Group=webvowl
+WorkingDirectory=/opt/webvowl
+
+ExecStart=/usr/bin/java \
+  --add-opens java.base/java.lang=ALL-UNNAMED \
+  -jar /opt/webvowl/owl2vowl.war
+
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> **Importante:** il flag `--add-opens java.base/java.lang=ALL-UNNAMED` è necessario per il corretto funzionamento della libreria OWL API con Java 21. Senza questo flag l'applicazione non si avvia.
+
+### 2.5 Avviare il servizio
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable webvowl
+sudo systemctl start webvowl
+
+# Verificare lo stato
+sudo systemctl status webvowl
+
+# Il servizio è disponibile su http://localhost:8080
+```
+
+---
+
+## Variabili d'ambiente
+
+WebVOWL attualmente non espone variabili d'ambiente di configurazione. Il servizio funziona out-of-the-box sulla porta 8080.
+
+---
+
+## Flag JVM richiesti
+
+| Flag | Motivo |
+|---|---|
+| `--add-opens java.base/java.lang=ALL-UNNAMED` | Necessario per la reflection usata dalla libreria OWL API su Java 21 |
+
+> **Nota:** nell'immagine Docker questo flag è già incluso nel `CMD` del Dockerfile.
+
+---
+
+## Nota per chi usa Apache HTTPD come reverse proxy
+
+Se si dispone già di un reverse proxy Apache HTTPD configurato per la versione precedente (Tomcat esterno), tenere presente che il modello architetturale è cambiato:
+
+- **Prima:** Apache parlava con un unico processo Tomcat su una singola porta, smistando le richieste per path (es. `/lodview`, `/lode`, `/webvowl`).
+- **Ora:** ogni visualizzatore è un processo Spring Boot autonomo in ascolto sulla propria porta locale.
+
+Tutte le applicazioni partono di default sulla porta **8080**. Se si eseguono più visualizzatori sulla stessa macchina, è necessario assegnare porte diverse tramite la variabile d'ambiente `SERVER_PORT` (vedi la [sezione porte](#porte) e il [README di LodView](https://github.com/teamdigitale/dati-semantic-lodview) per la tabella completa).
+
+Apache può continuare a fare reverse proxy, ma il backend non è più un unico Tomcat condiviso.
+
+### Virtual host dedicati
+
+Se si usa un dominio (o sottodominio) dedicato per ogni visualizzatore, la configurazione è minimale:
+
+```apache
+<VirtualHost *:443>
+    ServerName webvowl.example.com
+
+    ProxyPass / http://localhost:8082/
+    ProxyPassReverse / http://localhost:8082/
+
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port "443"
+
+    # ... configurazione SSL ...
+</VirtualHost>
+```
+
+### Path-based proxy (più visualizzatori sullo stesso dominio)
+
+Se si vogliono esporre più visualizzatori sotto path diversi dello stesso dominio, è necessario configurare `SERVER_PORT` e `SERVER_SERVLET_CONTEXT_PATH`.
+
+Esempio di file `.env` per WebVOWL in modalità path-based:
+
+```env
+SERVER_PORT=8082
+SERVER_SERVLET_CONTEXT_PATH=/webvowl
+```
+
+Configurazione Apache:
+
+```apache
+ProxyPass /webvowl http://localhost:8082/webvowl
+ProxyPassReverse /webvowl http://localhost:8082/webvowl
+```
+
+> **Nota:** senza `SERVER_SERVLET_CONTEXT_PATH`, le applicazioni Spring Boot servono su `/` (root) e il path-based proxy non funzionerebbe correttamente. Per la configurazione Apache completa con tutti i visualizzatori, vedere il [README di LodView](https://github.com/teamdigitale/dati-semantic-lodview).
+
+---
+
+## Porte
+
+| Porta | Protocollo | Descrizione |
+|---|---|---|
+| 8080 | HTTP | Interfaccia web WebVOWL + API OWL2VOWL (default, configurabile con `SERVER_PORT`) |


### PR DESCRIPTION
## Summary
- Replace the existing README with a comprehensive deployment guide
- Document Docker installation (recommended) and native systemd installation
- Document two-phase build: Node.js 20 frontend + Java 21/Gradle backend
- Document required JVM flag `--add-opens java.base/java.lang=ALL-UNNAMED`
- Add Apache HTTPD reverse proxy section (virtual host + path-based with `SERVER_SERVLET_CONTEXT_PATH`)
- Document `SERVER_PORT` for multi-visualizer coexistence on same host
- Add deprecation note for Tomcat external deployment

## Test plan
- [ ] Verify Docker `docker run` example works with `ghcr.io/teamdigitale/dati-semantic-webvowl:latest`
- [ ] Verify native build (npm + gradle) produces working artifact
- [ ] Verify JVM `--add-opens` flag is documented correctly for systemd